### PR TITLE
log tranzila connection errors

### DIFF
--- a/src/services/tranzilaIntegrationService.ts
+++ b/src/services/tranzilaIntegrationService.ts
@@ -59,7 +59,11 @@ export class TranzilaIntegrationService {
         description: t.description,
       }));
     } catch (error) {
-      console.error('Error fetching transactions from Tranzila:', error);
+      if (axios.isAxiosError(error) && !error.response) {
+        console.error('Connection error to Tranzila while fetching transactions:', error.message);
+      } else {
+        console.error('Error fetching transactions from Tranzila:', error);
+      }
       throw new Error('שגיאה בקבלת עסקאות מטרנזילה');
     }
   }
@@ -85,7 +89,11 @@ export class TranzilaIntegrationService {
       // החזר סט של transaction_index שכבר הופקו להם קבלות
       return new Set((data.documents || []).map((d: TranzilaDocument) => d.transaction_index));
     } catch (error) {
-      console.error('Error fetching existing receipts from Tranzila:', error);
+      if (axios.isAxiosError(error) && !error.response) {
+        console.error('Connection error to Tranzila while fetching existing receipts:', error.message);
+      } else {
+        console.error('Error fetching existing receipts from Tranzila:', error);
+      }
       throw new Error('שגיאה בקבלת קבלות קיימות מטרנזילה');
     }
   }
@@ -116,7 +124,11 @@ export class TranzilaIntegrationService {
 
       return res.data;
     } catch (error) {
-      console.error('Error creating receipt in Tranzila:', error);
+      if (axios.isAxiosError(error) && !error.response) {
+        console.error('Connection error to Tranzila while creating receipt:', error.message);
+      } else {
+        console.error('Error creating receipt in Tranzila:', error);
+      }
       throw new Error('שגיאה ביצירת קבלה בטרנזילה');
     }
   }

--- a/src/services/tranzilaService.ts
+++ b/src/services/tranzilaService.ts
@@ -33,7 +33,11 @@ export class TranzilaService {
       const textResponse = await response.text();
       return this.parseResponse(textResponse);
     } catch (error) {
-      console.error('Tranzila API Error:', error);
+      if (error instanceof TypeError) {
+        console.error('Connection error to Tranzila payment API:', error.message);
+      } else {
+        console.error('Tranzila API Error:', error);
+      }
       throw new Error('שגיאה בעיבוד התרומה');
     }
   }
@@ -84,7 +88,11 @@ export class TranzilaService {
 
       return response.data;
     } catch (error) {
-      console.error('Error getting transaction details:', error);
+      if (axios.isAxiosError(error) && !error.response) {
+        console.error('Connection error to Tranzila while getting transaction details:', error.message);
+      } else {
+        console.error('Error getting transaction details:', error);
+      }
       throw new Error('שגיאה בקבלת פרטי עסקה');
     }
   }


### PR DESCRIPTION
## Summary
- log Tranzila connection failures during payment processing
- capture connection errors when querying Tranzila for transactions and receipts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b49b1962848323945b716d4f498a5d