### PR TITLE
Improve Tranzila error reporting

### DIFF
--- a/src/services/tranzilaIntegrationService.ts
+++ b/src/services/tranzilaIntegrationService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { generateTranzilaHeaders } from './tranzilaAuth';
 import { Charge } from '../types';
+import { getErrorMessage } from '../utils/error';
 
 type TranzilaTransaction = { 
   transaction_index: string; 
@@ -59,7 +60,8 @@ export class TranzilaIntegrationService {
         description: t.description,
       }));
     } catch (error) {
-      console.error('Error fetching transactions from Tranzila:', error);
+      const message = getErrorMessage(error);
+      console.error('Error fetching transactions from Tranzila:', message);
       throw new Error('שגיאה בקבלת עסקאות מטרנזילה');
     }
   }
@@ -85,7 +87,8 @@ export class TranzilaIntegrationService {
       // החזר סט של transaction_index שכבר הופקו להם קבלות
       return new Set((data.documents || []).map((d: TranzilaDocument) => d.transaction_index));
     } catch (error) {
-      console.error('Error fetching existing receipts from Tranzila:', error);
+      const message = getErrorMessage(error);
+      console.error('Error fetching existing receipts from Tranzila:', message);
       throw new Error('שגיאה בקבלת קבלות קיימות מטרנזילה');
     }
   }
@@ -116,7 +119,8 @@ export class TranzilaIntegrationService {
 
       return res.data;
     } catch (error) {
-      console.error('Error creating receipt in Tranzila:', error);
+      const message = getErrorMessage(error);
+      console.error('Error creating receipt in Tranzila:', message);
       throw new Error('שגיאה ביצירת קבלה בטרנזילה');
     }
   }
@@ -165,7 +169,8 @@ export class TranzilaIntegrationService {
           // המתנה קצרה בין בקשות למניעת עומס על השרת
           await new Promise(resolve => setTimeout(resolve, 100));
         } catch (error) {
-          const errorMsg = `שגיאה ביצירת קבלה לעסקה ${tx.transaction_index}: ${error}`;
+          const errMessage = getErrorMessage(error);
+          const errorMsg = `שגיאה ביצירת קבלה לעסקה ${tx.transaction_index}: ${errMessage}`;
           console.error(errorMsg);
           results.errors.push(errorMsg);
         }
@@ -175,8 +180,9 @@ export class TranzilaIntegrationService {
       
       return results;
     } catch (error) {
-      console.error('Error in generateMissingReceipts:', error);
-      results.errors.push(`שגיאה כללית: ${error}`);
+      const message = getErrorMessage(error);
+      console.error('Error in generateMissingReceipts:', message);
+      results.errors.push(`שגיאה כללית: ${message}`);
       return results;
     }
   }
@@ -201,7 +207,8 @@ export class TranzilaIntegrationService {
         updatedAt: new Date(tx.date),
       }));
     } catch (error) {
-      console.error('Error syncing transactions:', error);
+      const message = getErrorMessage(error);
+      console.error('Error syncing transactions:', message);
       throw new Error('שגיאה בסנכרון עסקאות');
     }
   }

--- a/src/services/tranzilaService.ts
+++ b/src/services/tranzilaService.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { generateTranzilaHeaders } from './tranzilaAuth';
 import { TranzilaRequest } from '../types';
+import { getErrorMessage } from '../utils/error';
 
 // URLs for different Tranzila APIs
 const TRANZILA_PAYMENT_URL = 'https://secure5.tranzila.com/cgi-bin/tranzila71u.cgi';
@@ -33,7 +34,8 @@ export class TranzilaService {
       const textResponse = await response.text();
       return this.parseResponse(textResponse);
     } catch (error) {
-      console.error('Tranzila API Error:', error);
+      const message = getErrorMessage(error);
+      console.error('Tranzila API Error:', message);
       throw new Error('שגיאה בעיבוד התרומה');
     }
   }
@@ -84,7 +86,8 @@ export class TranzilaService {
 
       return response.data;
     } catch (error) {
-      console.error('Error getting transaction details:', error);
+      const message = getErrorMessage(error);
+      console.error('Error getting transaction details:', message);
       throw new Error('שגיאה בקבלת פרטי עסקה');
     }
   }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+
+export function getErrorMessage(error: unknown): string {
+  if (axios.isAxiosError(error)) {
+    const data = error.response?.data;
+    if (typeof data === 'string') {
+      return data;
+    }
+    if (data && typeof data === 'object') {
+      const maybeMessage = (data as { message?: unknown }).message;
+      if (typeof maybeMessage === 'string') {
+        return maybeMessage;
+      }
+      try {
+        return JSON.stringify(data);
+      } catch {
+        /* ignore */
+      }
+    }
+    return error.message;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable helper for extracting meaningful messages from thrown errors
- log formatted messages in Tranzila services to aid debugging

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 47 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b49d763f588323b529ad66a55bce83