### PR TITLE
Use dotenv for server configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@hebcal/core": "^5.10.1",
     "@types/node": "^24.3.0",
+    "dotenv": "^16.4.5",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",
     "lucide-react": "^0.344.0",

--- a/server/index.js
+++ b/server/index.js
@@ -1,26 +1,8 @@
+import 'dotenv/config';
 import { createServer } from 'http';
-import { readFileSync, appendFile } from 'fs';
+import { appendFile } from 'fs';
 import { resolve } from 'path';
 import { Pool } from 'pg';
-
-function loadEnv(path = '.env') {
-  try {
-    const envFile = readFileSync(resolve(process.cwd(), path), 'utf-8');
-    for (const line of envFile.split('\n')) {
-      const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/);
-      if (match) {
-        const key = match[1];
-        let value = match[2] || '';
-        value = value.replace(/(^['"]|['"]$)/g, '');
-        process.env[key] = value;
-      }
-    }
-  } catch {
-    // ignore missing env file
-  }
-}
-
-loadEnv();
 
 const required = [
   'VITE_TRANZILA_SUPPLIER_ID',


### PR DESCRIPTION
## Summary
- load environment variables via `dotenv` in the server
- declare `dotenv` dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bfef8bc94883239e2c578bf39d5072