### PR TITLE
Remove Tranzila integration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,9 +5,6 @@ import { resolve } from 'path';
 import { Pool } from 'pg';
 
 const required = [
-  'VITE_TRANZILA_SUPPLIER_ID',
-  'VITE_TRANZILA_PUBLIC_KEY',
-  'VITE_TRANZILA_PRIVATE_KEY',
   'PORT',
   'PGHOST',
   'PGUSER',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,11 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_TRANZILA_SUPPLIER_ID: string;
-  readonly VITE_TRANZILA_API_KEY: string;
-  readonly VITE_TRANZILA_TOKEN: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}


### PR DESCRIPTION
## Summary
- remove Tranzila environment variables from server
- drop Tranzila-specific Vite env declarations

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68bff05581988323aa7792e1c948df92