### PR TITLE
feat: manage uploaded PDFs with split option

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "dotenv": "^16.4.5",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",
+    "pdf-lib": "^1.17.1",
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
 import UploadsPage from './components/UploadsPage';
 import DonorsPage from './components/DonorsPage';
+import PdfListPage from './components/PdfListPage';
 
 function App() {
   return (
@@ -11,6 +12,7 @@ function App() {
         <Routes>
           <Route path="/" element={<UploadsPage />} />
           <Route path="/uploads" element={<UploadsPage />} />
+          <Route path="/pdfs" element={<PdfListPage />} />
           <Route path="/donors" element={<DonorsPage />} />
         </Routes>
       </Layout>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link, useLocation } from 'react-router-dom';
-import { Upload, Home, Users } from 'lucide-react';
+import { Upload, Home, Users, FileText } from 'lucide-react';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -34,7 +34,19 @@ export default function Layout({ children }: LayoutProps) {
                   <Upload className="h-4 w-4" />
                   <span>העלאות</span>
                 </Link>
-                
+
+                <Link
+                  to="/pdfs"
+                  className={`flex items-center space-x-2 space-x-reverse px-3 py-2 rounded-md text-sm font-medium transition-colors ${
+                    isActive('/pdfs')
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
+                  }`}
+                >
+                  <FileText className="h-4 w-4" />
+                  <span>קבצי PDF</span>
+                </Link>
+
                 <Link
                   to="/donors"
                   className={`flex items-center space-x-2 space-x-reverse px-3 py-2 rounded-md text-sm font-medium transition-colors ${

--- a/src/components/PdfListPage.tsx
+++ b/src/components/PdfListPage.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Scissors } from 'lucide-react';
+import { PDFDocument } from 'pdf-lib';
+
+interface SavedPdf {
+  id: string;
+  name: string;
+  data: string;
+}
+
+export default function PdfListPage() {
+  const [pdfs, setPdfs] = useState<SavedPdf[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('pdfs');
+    if (stored) {
+      setPdfs(JSON.parse(stored));
+    }
+  }, []);
+
+  const splitPdf = async (pdf: SavedPdf) => {
+    const byteArray = Uint8Array.from(atob(pdf.data.split(',')[1]), c => c.charCodeAt(0));
+    const doc = await PDFDocument.load(byteArray);
+    const totalPages = doc.getPageCount();
+    for (let i = 0; i < totalPages; i++) {
+      const newDoc = await PDFDocument.create();
+      const [page] = await newDoc.copyPages(doc, [i]);
+      newDoc.addPage(page);
+      const newBytes = await newDoc.save();
+      const blob = new Blob([newBytes], { type: 'application/pdf' });
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = `${pdf.name.replace(/\.pdf$/i, '')}-page-${i + 1}.pdf`;
+      link.click();
+      URL.revokeObjectURL(link.href);
+    }
+  };
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">קבצי PDF</h1>
+        <p className="text-gray-600 mt-2">ניהול קבצי PDF שהועלו</p>
+      </div>
+
+      <div className="bg-white rounded-lg shadow overflow-hidden">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">שם הקובץ</th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">פעולות</th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {pdfs.map(pdf => (
+              <tr key={pdf.id}>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  <button
+                    onClick={() => splitPdf(pdf)}
+                    className="inline-flex items-center space-x-1 space-x-reverse text-blue-600 hover:text-blue-900"
+                  >
+                    <Scissors className="h-4 w-4" />
+                    <span>פצל עמודים</span>
+                  </button>
+                </td>
+              </tr>
+            ))}
+            {pdfs.length === 0 && (
+              <tr>
+                <td colSpan={2} className="px-6 py-4 text-center text-sm text-gray-500">
+                  אין קבצי PDF זמינים
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/UploadsPage.tsx
+++ b/src/components/UploadsPage.tsx
@@ -17,6 +17,14 @@ export default function UploadsPage() {
   const excelInputRef = useRef<HTMLInputElement>(null);
   const pdfInputRef = useRef<HTMLInputElement>(null);
 
+  const fileToBase64 = (file: File): Promise<string> =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = reject;
+    });
+
   const handleDrag = (e: React.DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
@@ -58,15 +66,28 @@ export default function UploadsPage() {
 
         setUploadedFiles(prev => [...prev, newFile]);
 
+        const savePdf = async () => {
+          const data = await fileToBase64(file);
+          const stored = localStorage.getItem('pdfs');
+          const pdfs = stored ? JSON.parse(stored) : [];
+          pdfs.push({ id: newFile.id, name: file.name, data });
+          localStorage.setItem('pdfs', JSON.stringify(pdfs));
+        };
+
         // סימולציה של העלאה
         setTimeout(() => {
-          setUploadedFiles(prev => 
-            prev.map(f => 
-              f.id === newFile.id 
-                ? { ...f, status: Math.random() > 0.1 ? 'success' : 'error', errorMessage: 'שגיאה בהעלאת הקובץ' }
+          const isSuccess = Math.random() > 0.1;
+          setUploadedFiles(prev =>
+            prev.map(f =>
+              f.id === newFile.id
+                ? { ...f, status: isSuccess ? 'success' : 'error', errorMessage: 'שגיאה בהעלאת הקובץ' }
                 : f
             )
           );
+
+          if (isSuccess && fileType === 'pdf') {
+            savePdf();
+          }
         }, 2000);
       }
     });


### PR DESCRIPTION
## Summary
- store uploaded PDF data locally and track for later actions
- add PDF management page showing all PDFs with a split-per-page option
- add navigation route and link for the new PDF page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bff1627ff88323975f8733c69c24e5