### PR TITLE
feat: save uploaded files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+# Uploaded files
+server/uploads
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { createServer } from 'http';
-import { appendFile } from 'fs';
+import { appendFile, existsSync, mkdirSync, writeFile, createReadStream } from 'fs';
 import { resolve } from 'path';
 import { Pool } from 'pg';
 
@@ -22,6 +22,10 @@ const port = parseInt(process.env.PORT, 10);
 
 const logFile = resolve(process.cwd(), 'server', 'logs.txt');
 const emailLogFile = resolve(process.cwd(), 'server', 'emails.txt');
+const uploadDir = resolve(process.cwd(), 'server', 'uploads');
+if (!existsSync(uploadDir)) {
+  mkdirSync(uploadDir, { recursive: true });
+}
 
 async function sendEmail({ to, subject, text, html }) {
   try {
@@ -109,6 +113,39 @@ const server = createServer((req, res) => {
         res.end(JSON.stringify({ success: false }));
       }
     });
+  } else if (req.url === '/upload' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', () => {
+      try {
+        const { fileName, content } = JSON.parse(body);
+        const filePath = resolve(uploadDir, fileName);
+        writeFile(filePath, Buffer.from(content, 'base64'), err => {
+          if (err) {
+            console.error('Failed to save file', err);
+            res.writeHead(500, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ success: false }));
+            return;
+          }
+          res.writeHead(200, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ success: true, url: `/uploads/${fileName}` }));
+        });
+      } catch (err) {
+        console.error('Failed to process upload', err);
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false }));
+      }
+    });
+  } else if (req.url?.startsWith('/uploads/') && req.method === 'GET') {
+    const filePath = resolve(uploadDir, '.' + req.url.replace('/uploads', ''));
+    const stream = createReadStream(filePath);
+    stream.on('error', () => {
+      res.writeHead(404);
+      res.end();
+    });
+    stream.pipe(res);
   } else {
     res.writeHead(404);
     res.end();


### PR DESCRIPTION
## Summary
- add server endpoint to store uploaded files and serve them for download
- send files from client with axios and provide download links
- ignore uploaded files in git

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `node --check server/index.js`


------
https://chatgpt.com/codex/tasks/task_e_68bff20ed6c08323951c9e79018d662d