### PR TITLE
feat: use default port when PORT not provided

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -5,7 +5,6 @@ import { resolve } from 'path';
 import { Pool } from 'pg';
 
 const required = [
-  'PORT',
   'PGHOST',
   'PGUSER',
   'PGPASSWORD',
@@ -18,7 +17,7 @@ for (const key of required) {
   }
 }
 
-const port = parseInt(process.env.PORT, 10);
+const port = parseInt(process.env.PORT || '8080', 10);
 
 const logFile = resolve(process.cwd(), 'server', 'logs.txt');
 const emailLogFile = resolve(process.cwd(), 'server', 'emails.txt');


### PR DESCRIPTION
## Summary
- allow server to run without PORT env var by defaulting to 8080
- require only database vars on startup

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68bff32674708323bd8b44a15fde65ce