### PR TITLE
Proxy backend requests to port 3001

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,12 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    proxy: {
+      '/donors': 'http://localhost:3001',
+      '/donations': 'http://localhost:3001',
+      '/email': 'http://localhost:3001',
+      '/upload': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- route API calls through Vite proxy to backend port 3001

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c02707f3788323a1dd6337902142b8