### PR TITLE
Sync uploaded PDFs with list

### DIFF
--- a/src/components/UploadsPage.tsx
+++ b/src/components/UploadsPage.tsx
@@ -83,6 +83,11 @@ export default function UploadsPage() {
                     : f
                 )
               );
+              if (fileType === 'pdf') {
+                const stored = JSON.parse(localStorage.getItem('pdfs') || '[]');
+                stored.push({ id: newFile.id, name: file.name, data: result });
+                localStorage.setItem('pdfs', JSON.stringify(stored));
+              }
             })
             .catch(() => {
               setUploadedFiles(prev =>
@@ -127,7 +132,15 @@ export default function UploadsPage() {
   };
 
   const removeFile = (id: string) => {
-    setUploadedFiles(prev => prev.filter(f => f.id !== id));
+    setUploadedFiles(prev => {
+      const file = prev.find(f => f.id === id);
+      if (file?.type === 'pdf') {
+        const stored = JSON.parse(localStorage.getItem('pdfs') || '[]');
+        const updated = stored.filter((p: { id: string }) => p.id !== id);
+        localStorage.setItem('pdfs', JSON.stringify(updated));
+      }
+      return prev.filter(f => f.id !== id);
+    });
   };
 
   const getStatusIcon = (status: string) => {


### PR DESCRIPTION
## Summary
- Save successfully uploaded PDFs to localStorage so they appear on the PDF list page
- Remove PDFs from localStorage when deleted from the uploads list

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68c06f96b5348323baa964958d42ad62