### PR TITLE
feat: add connection logs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -104,6 +104,7 @@ pool
   });
 
 const server = createServer((req, res) => {
+  console.log(`Incoming request: ${req.method} ${req.url}`);
   if (req.url === '/health') {
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ status: 'ok' }));

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Upload, Home, Users, FileText } from 'lucide-react';
 
@@ -8,6 +8,17 @@ interface LayoutProps {
 
 export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
+
+  useEffect(() => {
+    fetch('/health')
+      .then(res => res.json())
+      .then(data => {
+        console.log('Server health check:', data);
+      })
+      .catch(err => {
+        console.error('Server health check failed', err);
+      });
+  }, []);
 
   const isActive = (path: string) => location.pathname === path;
 


### PR DESCRIPTION
## Summary
- log incoming HTTP requests on the server
- check server health from layout and log result in console

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c07e3f2dc08323b81c9756fe9e1b44