### PR TITLE
Use API_URL for server requests

### DIFF
--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -1,6 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import { Users, Mail, Plus, Eye, Send, FileText, CheckCircle, X } from 'lucide-react';
 
+// Use an environment variable so API calls work when the app is served statically
+const API_URL = import.meta.env.VITE_API_URL || '';
+
 interface Donation {
   id: string;
   amount: number;
@@ -40,7 +43,7 @@ export default function DonorsPage() {
   });
 
   useEffect(() => {
-    fetch('/donors')
+    fetch(`${API_URL}/donors`)
       .then(res => res.json())
       .then(data => {
         const loaded = data.map((d: any) => ({
@@ -61,7 +64,7 @@ export default function DonorsPage() {
   const handleAddDonor = async () => {
     if (newDonor.donorNumber && newDonor.fullName && newDonor.email) {
       try {
-        const res = await fetch('/donors', {
+        const res = await fetch(`${API_URL}/donors`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(newDonor)
@@ -81,7 +84,7 @@ export default function DonorsPage() {
     const donation = donor?.donations.find(d => d.id === donationId);
     if (!donor || !donation) return;
     try {
-      await fetch('/email', {
+      await fetch(`${API_URL}/email`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -138,7 +141,7 @@ export default function DonorsPage() {
       let pdfUrl: string | undefined;
       if (newDonation.file) {
         const content = await fileToBase64(newDonation.file);
-        const uploadRes = await fetch('/upload', {
+        const uploadRes = await fetch(`${API_URL}/upload`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ fileName: newDonation.file.name, content })
@@ -146,7 +149,7 @@ export default function DonorsPage() {
         const uploadData = await uploadRes.json();
         pdfUrl = uploadData.url;
       }
-      const res = await fetch('/donations', {
+      const res = await fetch(`${API_URL}/donations`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,9 @@ import React, { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { Upload, Home, Users, FileText } from 'lucide-react';
 
+// Use an environment variable so the health check works even when the app is served statically
+const API_URL = import.meta.env.VITE_API_URL || '';
+
 interface LayoutProps {
   children: React.ReactNode;
 }
@@ -10,7 +13,7 @@ export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
 
   useEffect(() => {
-    fetch('/health')
+    fetch(`${API_URL}/health`)
       .then(res => res.json())
       .then(data => {
         console.log('Server health check:', data);


### PR DESCRIPTION
## Summary
- use VITE_API_URL env var for health check requests
- route donor-related API calls through configured base URL

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c089461c5c8323a287d6cc69f1d238