### PR TITLE
feat: list uploaded pdfs from server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { createServer } from 'http';
-import { appendFile, existsSync, mkdirSync, writeFile, createReadStream } from 'fs';
+import { appendFile, existsSync, mkdirSync, writeFile, createReadStream, readdir } from 'fs';
 import { resolve } from 'path';
 import { Pool } from 'pg';
 
@@ -280,6 +280,20 @@ const server = createServer((req, res) => {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ success: false }));
       }
+    });
+  } else if (req.url === '/pdfs' && req.method === 'GET') {
+    readdir(uploadDir, (err, files) => {
+      if (err) {
+        console.error('Failed to read uploads directory', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false }));
+        return;
+      }
+      const pdfs = files
+        .filter(f => f.toLowerCase().endsWith('.pdf'))
+        .map(name => ({ name, url: `/uploads/${name}` }));
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(pdfs));
     });
   } else if (req.url === '/upload' && req.method === 'POST') {
     console.log('Received upload request:', req.url);


### PR DESCRIPTION
## Summary
- add backend endpoint to list uploaded PDF files
- load saved PDFs from server in PDF list page and allow splitting

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c0a32318f48323b6f188540e19d611