### PR TITLE
feat: list split pdfs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -313,6 +313,22 @@ const server = createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(pdfs));
     });
+  } else if (req.url === '/split-pdfs' && req.method === 'GET') {
+    pool
+      .query('SELECT original_name, page_number, file_url FROM pdf_pages ORDER BY id')
+      .then(result => {
+        const pdfs = result.rows.map(row => ({
+          name: `${row.original_name} - page ${row.page_number}`,
+          url: row.file_url,
+        }));
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(pdfs));
+      })
+      .catch(err => {
+        console.error('Failed to fetch split PDFs', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false }));
+      });
   } else if (req.url === '/split-pdf' && req.method === 'POST') {
     let body = '';
     req.on('data', chunk => {

--- a/src/components/PdfListPage.tsx
+++ b/src/components/PdfListPage.tsx
@@ -8,14 +8,32 @@ interface SavedPdf {
   url: string;
 }
 
+interface SplitPdf {
+  name: string;
+  url: string;
+}
+
 export default function PdfListPage() {
   const [pdfs, setPdfs] = useState<SavedPdf[]>([]);
+  const [splitPdfs, setSplitPdfs] = useState<SplitPdf[]>([]);
 
-  useEffect(() => {
+  const fetchPdfs = () => {
     fetch(`${API_URL}/pdfs`)
       .then(res => res.json())
       .then(data => setPdfs(data))
       .catch(err => console.error('Failed to fetch pdfs', err));
+  };
+
+  const fetchSplitPdfs = () => {
+    fetch(`${API_URL}/split-pdfs`)
+      .then(res => res.json())
+      .then(data => setSplitPdfs(data))
+      .catch(err => console.error('Failed to fetch split pdfs', err));
+  };
+
+  useEffect(() => {
+    fetchPdfs();
+    fetchSplitPdfs();
   }, []);
 
   const splitPdf = async (pdf: SavedPdf) => {
@@ -24,6 +42,7 @@ export default function PdfListPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: pdf.name }),
     });
+    fetchSplitPdfs();
   };
 
   return (
@@ -65,6 +84,44 @@ export default function PdfListPage() {
             )}
           </tbody>
         </table>
+      </div>
+
+      <div>
+        <h2 className="text-2xl font-bold text-gray-900">קבצים מפוצלים</h2>
+        <div className="bg-white rounded-lg shadow overflow-hidden mt-4">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">שם הקובץ</th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">קישור</th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {splitPdfs.map(pdf => (
+                <tr key={pdf.url}>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <a
+                      href={`${API_URL}${pdf.url}`}
+                      className="text-blue-600 hover:text-blue-900"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      הורדה
+                    </a>
+                  </td>
+                </tr>
+              ))}
+              {splitPdfs.length === 0 && (
+                <tr>
+                  <td colSpan={2} className="px-6 py-4 text-center text-sm text-gray-500">
+                    אין קבצים מפוצלים
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add backend endpoint to fetch split PDFs
- show split PDF files alongside uploaded ones

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)


------
https://chatgpt.com/codex/tasks/task_e_68c0aa4d62fc8323a1e2743c6ff4742a