### PR TITLE
Group split PDFs with originals and prevent duplicate splits

### DIFF
--- a/src/components/PdfListPage.tsx
+++ b/src/components/PdfListPage.tsx
@@ -3,19 +3,19 @@ import { Scissors } from 'lucide-react';
 
 const API_URL = import.meta.env.VITE_API_URL || '';
 
-interface SavedPdf {
-  name: string;
-  url: string;
-}
-
 interface SplitPdf {
   name: string;
   url: string;
 }
 
+interface SavedPdf {
+  name: string;
+  url: string;
+  splitPdfs: SplitPdf[];
+}
+
 export default function PdfListPage() {
   const [pdfs, setPdfs] = useState<SavedPdf[]>([]);
-  const [splitPdfs, setSplitPdfs] = useState<SplitPdf[]>([]);
 
   const fetchPdfs = () => {
     fetch(`${API_URL}/pdfs`)
@@ -24,16 +24,8 @@ export default function PdfListPage() {
       .catch(err => console.error('Failed to fetch pdfs', err));
   };
 
-  const fetchSplitPdfs = () => {
-    fetch(`${API_URL}/split-pdfs`)
-      .then(res => res.json())
-      .then(data => setSplitPdfs(data))
-      .catch(err => console.error('Failed to fetch split pdfs', err));
-  };
-
   useEffect(() => {
     fetchPdfs();
-    fetchSplitPdfs();
   }, []);
 
   const splitPdf = async (pdf: SavedPdf) => {
@@ -42,7 +34,7 @@ export default function PdfListPage() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: pdf.name }),
     });
-    fetchSplitPdfs();
+    fetchPdfs();
   };
 
   return (
@@ -62,18 +54,41 @@ export default function PdfListPage() {
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {pdfs.map(pdf => (
-              <tr key={pdf.url}>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                  <button
-                    onClick={() => splitPdf(pdf)}
-                    className="inline-flex items-center space-x-1 space-x-reverse text-blue-600 hover:text-blue-900"
-                  >
-                    <Scissors className="h-4 w-4" />
-                    <span>פצל עמודים</span>
-                  </button>
-                </td>
-              </tr>
+              <React.Fragment key={pdf.url}>
+                <tr>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <button
+                      onClick={() => splitPdf(pdf)}
+                      disabled={pdf.splitPdfs.length > 0}
+                      className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length > 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}`
+                    >
+                      <Scissors className="h-4 w-4" />
+                      <span>פצל עמודים</span>
+                    </button>
+                  </td>
+                </tr>
+                {pdf.splitPdfs.length > 0 && (
+                  <tr>
+                    <td colSpan={2} className="px-6 py-4 bg-gray-50">
+                      <ul className="list-disc pr-5 space-y-1">
+                        {pdf.splitPdfs.map(p => (
+                          <li key={p.url}>
+                            <a
+                              href={`${API_URL}${p.url}`}
+                              className="text-blue-600 hover:text-blue-900"
+                              target="_blank"
+                              rel="noopener noreferrer"
+                            >
+                              {p.name}
+                            </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
             ))}
             {pdfs.length === 0 && (
               <tr>
@@ -84,44 +99,6 @@ export default function PdfListPage() {
             )}
           </tbody>
         </table>
-      </div>
-
-      <div>
-        <h2 className="text-2xl font-bold text-gray-900">קבצים מפוצלים</h2>
-        <div className="bg-white rounded-lg shadow overflow-hidden mt-4">
-          <table className="min-w-full divide-y divide-gray-200">
-            <thead className="bg-gray-50">
-              <tr>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">שם הקובץ</th>
-                <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">קישור</th>
-              </tr>
-            </thead>
-            <tbody className="bg-white divide-y divide-gray-200">
-              {splitPdfs.map(pdf => (
-                <tr key={pdf.url}>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    <a
-                      href={`${API_URL}${pdf.url}`}
-                      className="text-blue-600 hover:text-blue-900"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      הורדה
-                    </a>
-                  </td>
-                </tr>
-              ))}
-              {splitPdfs.length === 0 && (
-                <tr>
-                  <td colSpan={2} className="px-6 py-4 text-center text-sm text-gray-500">
-                    אין קבצים מפוצלים
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
-        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Return PDF listings with any split pages grouped under their original file and block resplitting already processed PDFs
- Display split pages beneath each PDF in the list and disable the split button after a file is split

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ac97a99083238012312b4e2f667a