### PR TITLE
Map split PDFs to donors via Excel upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-router-dom": "^7.8.2",
     "axios": "^1.6.8",
     "crypto-js": "^4.2.0",
-    "pg": "^8.11.3"
+    "pg": "^8.11.3",
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",


### PR DESCRIPTION
## Summary
- add XLSX parsing on server to associate split PDF pages with donors
- enable Excel upload from PDF list to trigger assignment
- include `xlsx` dependency

## Testing
- `npm install xlsx@^0.18.5` *(failed: 403 Forbidden)*
- `npm run lint` *(failed: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c0ad7bbcc88323b6646e6942e1277f