### PR TITLE
feat: assign split PDFs to donors via Excel

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,17 +13,18 @@
   "dependencies": {
     "@hebcal/core": "^5.10.1",
     "@types/node": "^24.3.0",
+    "axios": "^1.6.8",
+    "crypto-js": "^4.2.0",
     "dotenv": "^16.4.5",
     "html2canvas": "^1.4.1",
     "jspdf": "^3.0.1",
-    "pdf-lib": "^1.17.1",
     "lucide-react": "^0.344.0",
+    "pdf-lib": "^1.17.1",
+    "pg": "^8.11.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^7.8.2",
-    "axios": "^1.6.8",
-    "crypto-js": "^4.2.0",
-    "pg": "^8.11.3"
+    "xlsx": "^0.18.5"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ import { appendFile, existsSync, mkdirSync, writeFile, createReadStream, readdir
 import { resolve } from 'path';
 import { Pool } from 'pg';
 import { PDFDocument } from 'pdf-lib';
+import XLSX from 'xlsx';
 
 const required = [
   'PGHOST',
@@ -376,6 +377,56 @@ const server = createServer((req, res) => {
         res.end(JSON.stringify({ success: true }));
       } catch (err) {
         console.error('Failed to split PDF', err);
+        res.writeHead(500, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: false }));
+      }
+    });
+  } else if (req.url === '/assign-excel' && req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      try {
+        const { name, content } = JSON.parse(body);
+        const buffer = Buffer.from(content, 'base64');
+        const workbook = XLSX.read(buffer, { type: 'buffer' });
+        const sheet = workbook.Sheets[workbook.SheetNames[0]];
+        const rows = XLSX.utils.sheet_to_json(sheet, { header: 1 });
+        const { rows: pageRows } = await pool.query(
+          'SELECT file_url FROM pdf_pages WHERE original_name = $1 ORDER BY page_number',
+          [name]
+        );
+        const pages = pageRows.map(r => r.file_url);
+        for (let i = 1; i < rows.length && i - 1 < pages.length; i++) {
+          const row = rows[i];
+          const donorNumber = row[0]?.toString() || '';
+          const fullName = `${row[6] || ''} ${row[8] || ''} ${row[7] || ''}`.trim() || 'Unknown Donor';
+          const amount = parseFloat(row[4]) || 0;
+          const donationDate = row[12] ? new Date(row[12]) : new Date();
+          let donorId;
+          const existing = await pool.query(
+            'SELECT id FROM donors WHERE donor_number = $1',
+            [donorNumber]
+          );
+          if (existing.rowCount > 0) {
+            donorId = existing.rows[0].id;
+          } else {
+            const inserted = await pool.query(
+              'INSERT INTO donors(donor_number, full_name, email) VALUES($1, $2, $3) RETURNING id',
+              [donorNumber, fullName, `${donorNumber}@example.com`]
+            );
+            donorId = inserted.rows[0].id;
+          }
+          await pool.query(
+            'INSERT INTO donations(donor_id, amount, donation_date, description, pdf_url) VALUES($1, $2, $3, $4, $5)',
+            [donorId, amount, donationDate, row[2] || '', pages[i - 1]]
+          );
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ success: true }));
+      } catch (err) {
+        console.error('Failed to assign donors from excel', err);
         res.writeHead(500, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ success: false }));
       }

--- a/src/components/PdfListPage.tsx
+++ b/src/components/PdfListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Scissors } from 'lucide-react';
+import { Scissors, Upload } from 'lucide-react';
 
 const API_URL = import.meta.env.VITE_API_URL || '';
 
@@ -37,6 +37,28 @@ export default function PdfListPage() {
     fetchPdfs();
   };
 
+  const uploadExcel = (pdf: SavedPdf) => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.xlsx,.xls';
+    input.onchange = e => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onload = async ev => {
+          const base64 = (ev.target?.result as string).split(',')[1];
+          await fetch(`${API_URL}/assign-excel`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name: pdf.name, content: base64 }),
+          });
+        };
+        reader.readAsDataURL(file);
+      }
+    };
+    input.click();
+  };
+
   return (
     <div className="space-y-8">
       <div>
@@ -57,16 +79,26 @@ export default function PdfListPage() {
               <React.Fragment key={pdf.url}>
                 <tr>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
-                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                    <button
-                      onClick={() => splitPdf(pdf)}
-                      disabled={pdf.splitPdfs.length > 0}
-                      className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length > 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}`
-                    >
-                      <Scissors className="h-4 w-4" />
-                      <span>פצל עמודים</span>
-                    </button>
-                  </td>
+                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                      <div className="flex items-center space-x-4 space-x-reverse">
+                        <button
+                          onClick={() => splitPdf(pdf)}
+                          disabled={pdf.splitPdfs.length > 0}
+                          className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length > 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
+                        >
+                          <Scissors className="h-4 w-4" />
+                          <span>פצל עמודים</span>
+                        </button>
+                        <button
+                          onClick={() => uploadExcel(pdf)}
+                          disabled={pdf.splitPdfs.length === 0}
+                          className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length === 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
+                        >
+                          <Upload className="h-4 w-4" />
+                          <span>שיוך מאקסל</span>
+                        </button>
+                      </div>
+                    </td>
                 </tr>
                 {pdf.splitPdfs.length > 0 && (
                   <tr>


### PR DESCRIPTION
## Summary
- add `xlsx` dependency
- new `/assign-excel` API to link split PDF pages to donors using uploaded Excel
- allow uploading an Excel per PDF to associate pages with donors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aff5950083239e9655922897de6b