### PR TITLE
Attach donation PDFs to emails

### DIFF
--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -91,7 +91,8 @@ export default function DonorsPage() {
           to: donor.email,
           subject: 'אישור תרומה',
           text: `תודה על תרומתך בסך ${formatCurrency(donation.amount)}`,
-          donationId
+          donationId,
+          pdfUrl: donation.pdfUrl
         })
       });
       setDonors(prev =>


### PR DESCRIPTION
## Summary
- Include optional attachments in backend sendEmail helper
- Attach donation's PDF file when sending confirmation emails
- Pass donation PDF URL from frontend when triggering email

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm run build` (fails: vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1537cba3883239be3d86c1aab6fc8