### PR TITLE
Add resend email button for donation receipts

### DIFF
--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -506,9 +506,18 @@ export default function DonorsPage() {
                         
                         <div className="flex items-center space-x-2 space-x-reverse">
                           {donation.emailSent ? (
-                            <div className="flex items-center space-x-1 space-x-reverse text-green-600">
-                              <CheckCircle className="h-4 w-4" />
-                              <span className="text-sm">נשלח</span>
+                            <div className="flex items-center space-x-2 space-x-reverse">
+                              <div className="flex items-center space-x-1 space-x-reverse text-green-600">
+                                <CheckCircle className="h-4 w-4" />
+                                <span className="text-sm">נשלח</span>
+                              </div>
+                              <button
+                                onClick={() => handleSendEmail(donor.id, donation.id)}
+                                className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm flex items-center space-x-1 space-x-reverse transition-colors"
+                              >
+                                <Send className="h-3 w-3" />
+                                <span>שלח שוב</span>
+                              </button>
                             </div>
                           ) : (
                             <button


### PR DESCRIPTION
## Summary
- add option to resend emails for donations that already have receipts sent

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c15392b8048323a678f9268aad3084