### PR TITLE
Prevent duplicate Excel assignment and show linked donor list

### DIFF
--- a/src/components/PdfListPage.tsx
+++ b/src/components/PdfListPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Scissors, Upload } from 'lucide-react';
+import { Scissors, Upload, List, CheckCircle } from 'lucide-react';
 
 const API_URL = import.meta.env.VITE_API_URL || '';
 
@@ -12,6 +12,16 @@ interface SavedPdf {
   name: string;
   url: string;
   splitPdfs: SplitPdf[];
+  excelAssigned?: boolean;
+  assignments?: Assignment[];
+  showAssignments?: boolean;
+}
+
+interface Assignment {
+  donorNumber: string;
+  fullName: string;
+  amount: number;
+  donationDate: string;
 }
 
 export default function PdfListPage() {
@@ -47,16 +57,34 @@ export default function PdfListPage() {
         const reader = new FileReader();
         reader.onload = async ev => {
           const base64 = (ev.target?.result as string).split(',')[1];
-          await fetch(`${API_URL}/assign-excel`, {
+          const res = await fetch(`${API_URL}/assign-excel`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name: pdf.name, content: base64 }),
           });
+          const data = await res.json();
+          if (data.success) {
+            setPdfs(prev =>
+              prev.map(p =>
+                p.name === pdf.name
+                  ? { ...p, excelAssigned: true, assignments: data.assignments, showAssignments: true }
+                  : p
+              )
+            );
+          }
         };
         reader.readAsDataURL(file);
       }
     };
     input.click();
+  };
+
+  const toggleAssignments = (pdf: SavedPdf) => {
+    setPdfs(prev =>
+      prev.map(p =>
+        p.name === pdf.name ? { ...p, showAssignments: !p.showAssignments } : p
+      )
+    );
   };
 
   return (
@@ -79,27 +107,36 @@ export default function PdfListPage() {
               <React.Fragment key={pdf.url}>
                 <tr>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{pdf.name}</td>
-                    <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                      <div className="flex items-center space-x-4 space-x-reverse">
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                    <div className="flex items-center space-x-4 space-x-reverse">
+                      <button
+                        onClick={() => splitPdf(pdf)}
+                        disabled={pdf.splitPdfs.length > 0}
+                        className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length > 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
+                      >
+                        <Scissors className="h-4 w-4" />
+                        <span>פצל עמודים</span>
+                      </button>
+                      <button
+                        onClick={() => uploadExcel(pdf)}
+                        disabled={pdf.splitPdfs.length === 0 || pdf.excelAssigned}
+                        className={`inline-flex items-center space-x-1 space-x-reverse ${(pdf.splitPdfs.length === 0 || pdf.excelAssigned) ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
+                      >
+                        <Upload className="h-4 w-4" />
+                        <span>שיוך מאקסל</span>
+                      </button>
+                      {pdf.excelAssigned && <CheckCircle className="h-4 w-4 text-green-600" />}
+                      {pdf.excelAssigned && (
                         <button
-                          onClick={() => splitPdf(pdf)}
-                          disabled={pdf.splitPdfs.length > 0}
-                          className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length > 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
+                          onClick={() => toggleAssignments(pdf)}
+                          className="inline-flex items-center space-x-1 space-x-reverse text-blue-600 hover:text-blue-900"
                         >
-                          <Scissors className="h-4 w-4" />
-                          <span>פצל עמודים</span>
+                          <List className="h-4 w-4" />
+                          <span>הצג רשימה</span>
                         </button>
-                        <button
-                          onClick={() => uploadExcel(pdf)}
-                          disabled={pdf.splitPdfs.length === 0}
-                          className={`inline-flex items-center space-x-1 space-x-reverse ${pdf.splitPdfs.length === 0 ? 'text-gray-400 cursor-not-allowed' : 'text-blue-600 hover:text-blue-900'}`}
-                        >
-                          <Upload className="h-4 w-4" />
-                          <span>שיוך מאקסל</span>
-                        </button>
-                      </div>
-                    </td>
-  
+                      )}
+                    </div>
+                  </td>
                 </tr>
                 {pdf.splitPdfs.length > 0 && (
                   <tr>
@@ -115,6 +152,19 @@ export default function PdfListPage() {
                             >
                               {p.name}
                             </a>
+                          </li>
+                        ))}
+                      </ul>
+                    </td>
+                  </tr>
+                )}
+                {pdf.showAssignments && pdf.assignments && pdf.assignments.length > 0 && (
+                  <tr>
+                    <td colSpan={2} className="px-6 py-4 bg-gray-50">
+                      <ul className="list-disc pr-5 space-y-1">
+                        {pdf.assignments.map((a, idx) => (
+                          <li key={idx}>
+                            {`${a.donorNumber} - ${a.fullName} - ${a.amount} - ${new Date(a.donationDate).toLocaleDateString('he-IL')}`}
                           </li>
                         ))}
                       </ul>


### PR DESCRIPTION
## Summary
- Return assignment data from `/assign-excel` and block repeat assignments
- Report assignment status in `/pdfs` response with donor list
- Display Excel assignment indicator and list toggle in PDF list page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68c155c3748c83239bc1391ff9497709