### PR TITLE
refactor: update email template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,4 @@ SMTP_PORT=587
 SMTP_USER=yourUsername
 SMTP_PASS=yourPassword
 SMTP_SECURE=ture
-SMTP_FROM_EMAIL=from@example.com
+SMTP_FROM="צדקה עניי ישראל ובני ירושלים <from@example.com>"

--- a/server/index.js
+++ b/server/index.js
@@ -45,7 +45,9 @@ async function sendEmail({ to, subject, text, html, attachments }) {
     });
 
     await transporter.sendMail({
-      from: process.env.SMTP_FROM || process.env.SMTP_USER,
+      from:
+        process.env.SMTP_FROM ||
+        `צדקה עניי ישראל ובני ירושלים <${process.env.SMTP_USER}>`,
       to,
       subject,
       text,

--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -89,8 +89,11 @@ export default function DonorsPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           to: donor.email,
-          subject: 'אישור תרומה',
-          text: `תודה על תרומתך בסך ${formatCurrency(donation.amount)}`,
+          subject: 'תודה על התרומה שלך',
+          text:
+            'שלום,\nמצורף הקבלה שלכם על התרומה שלכם.\nהתרומה שלכם מוכרת לפי סעיף 46.\n\nבברכה,\nצדקה עניי ישראל ובני ירושלים',
+          html:
+            '<p>שלום,</p><p>מצורף הקבלה שלכם על התרומה שלכם.</p><p>התרומה שלכם מוכרת לפי סעיף 46.</p><p>בברכה,<br/>צדקה עניי ישראל ובני ירושלים</p>',
           donationId,
           pdfUrl: donation.pdfUrl
         })


### PR DESCRIPTION
## Summary
- update donation email template and send with PDF receipts
- set default sender name without "תהיה"
- document SMTP_FROM in environment example

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c156754b7c8323b56e05ed6215b168