### PR TITLE
Define missing sending state in DonorsPage

### DIFF
--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -46,6 +46,8 @@ export default function DonorsPage() {
   const [minTotal, setMinTotal] = useState('');
   const [maxTotal, setMaxTotal] = useState('');
   const [onlyPending, setOnlyPending] = useState(false);
+  const [sendingDonationId, setSendingDonationId] = useState<string | null>(null);
+  const [sendingAll, setSendingAll] = useState(false);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add `sendingDonationId` and `sendingAll` state to DonorsPage to fix ReferenceError.

## Testing
- `npm test` *(fails: command not found: npm)*


------
https://chatgpt.com/codex/tasks/task_e_68c181a2dfe0832394097fb49336fb1c