### PR TITLE
Add sender name options for donation emails

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,7 +32,7 @@ if (!existsSync(splitDir)) {
   mkdirSync(splitDir, { recursive: true });
 }
 
-async function sendEmail({ to, subject, text, html, attachments }) {
+async function sendEmail({ to, subject, text, html, attachments, senderName }) {
   try {
     const nodemailer = await import('nodemailer');
     const transporter = nodemailer.createTransport({
@@ -44,10 +44,23 @@ async function sendEmail({ to, subject, text, html, attachments }) {
       }
     });
 
+    const defaultFrom =
+      process.env.SMTP_FROM ||
+      (process.env.SMTP_USER
+        ? `צדקה עניי ישראל ובני ירושלים <${process.env.SMTP_USER}>`
+        : undefined);
+
+    let from = defaultFrom;
+    if (senderName) {
+      const match = process.env.SMTP_FROM?.match(/<([^>]+)>/);
+      const emailAddress = match?.[1] || process.env.SMTP_USER;
+      if (emailAddress) {
+        from = `${senderName} <${emailAddress}>`;
+      }
+    }
+
     await transporter.sendMail({
-      from:
-        process.env.SMTP_FROM ||
-        `צדקה עניי ישראל ובני ירושלים <${process.env.SMTP_USER}>`,
+      from,
       to,
       subject,
       text,

--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -24,6 +24,11 @@ interface Donor {
 }
 
 export default function DonorsPage() {
+  const SENDER_OPTIONS = [
+    { senderName: 'צדקת עניי ארץ ישראל', label: 'שלח מייל בשם צדקת עניי ארץ ישראל' },
+    { senderName: 'בני ירושלים', label: 'שלח מייל בשם בני ירושלים' }
+  ] as const;
+
   const [donors, setDonors] = useState<Donor[]>([]);
 
   const [selectedDonor, setSelectedDonor] = useState<Donor | null>(null);
@@ -87,7 +92,11 @@ export default function DonorsPage() {
     }
   };
 
-  const handleSendEmail = async (donorId: string, donationId: string) => {
+  const handleSendEmail = async (
+    donorId: string,
+    donationId: string,
+    senderName = SENDER_OPTIONS[0].senderName
+  ) => {
     const donor = donors.find(d => d.id === donorId);
     const donation = donor?.donations.find(d => d.id === donationId);
     if (!donor || !donation) return;
@@ -104,7 +113,8 @@ export default function DonorsPage() {
           html:
             '<p>שלום,</p><p>מצורף הקבלה שלכם על התרומה שלכם.</p><p>התרומה שלכם מוכרת לפי סעיף 46.</p><p>בברכה,<br/>צדקה עניי ישראל ובני ירושלים</p>',
           donationId,
-          pdfUrl: donation.pdfUrl
+          pdfUrl: donation.pdfUrl,
+          senderName
         })
       });
       setDonors(prev =>
@@ -134,7 +144,7 @@ export default function DonorsPage() {
       for (const donor of donors) {
         for (const donation of donor.donations) {
           if (!donation.emailSent) {
-            await handleSendEmail(donor.id, donation.id);
+            await handleSendEmail(donor.id, donation.id, SENDER_OPTIONS[0].senderName);
           }
         }
       }
@@ -210,20 +220,25 @@ export default function DonorsPage() {
   const renderSendButton = (donation: Donation, donorId: string) => {
     const isSending = sendingDonationId === donation.id;
     return (
-      <button
-        onClick={() => handleSendEmail(donorId, donation.id)}
-        disabled={isSending}
-        className={`bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm flex items-center space-x-1 space-x-reverse transition active:scale-95 ${isSending ? 'opacity-50 cursor-not-allowed' : ''}`}
-      >
-        {isSending ? (
-          <span>מעבד...</span>
-        ) : (
-          <>
-            <Send className="h-3 w-3" />
-            <span>{donation.emailSent ? 'שלח שוב' : 'שלח מייל'}</span>
-          </>
-        )}
-      </button>
+      <div className="flex flex-col space-y-2">
+        {SENDER_OPTIONS.map(option => (
+          <button
+            key={option.senderName}
+            onClick={() => handleSendEmail(donorId, donation.id, option.senderName)}
+            disabled={isSending}
+            className={`bg-blue-600 hover:bg-blue-700 text-white px-3 py-1 rounded text-sm flex items-center space-x-1 space-x-reverse transition active:scale-95 ${isSending ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            {isSending ? (
+              <span>מעבד...</span>
+            ) : (
+              <>
+                <Send className="h-3 w-3" />
+                <span>{option.label}</span>
+              </>
+            )}
+          </button>
+        ))}
+      </div>
     );
   };
 


### PR DESCRIPTION
## Summary
- add dual send-email options per donation so staff can choose the sender identity
- include the chosen sender name in the email payload and let the server build a matching From header

## Testing
- npm run lint *(fails: Cannot find package '@eslint/js/index.js' because @eslint/js cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbbe93bfa88323a2fc35b34bf2499a