### PR TITLE
Add digital signing for emailed PDFs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Uploaded files
 server/uploads
+server/signed
 
 # Editor directories and files
 .vscode/*


### PR DESCRIPTION
## Summary
- create a dedicated directory and helper that stamps emailed PDFs with a configurable signature
- ensure the email endpoint signs attachments before sending so all outgoing PDFs include the digital signature
- ignore generated signed PDF artifacts in version control

## Testing
- npm run lint *(fails: missing eslint dependencies because npm install is blocked by registry access 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc7fc9c9c8323983b1c1fbab4cf31