### PR TITLE
Add donor profile card with tabbed sections

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,19 @@ export interface Donation {
   sentDate?: Date;
 }
 
+export type DonorNameEntry =
+  | string
+  | {
+      id?: string | number;
+      name: string;
+      relation?: string;
+      notes?: string;
+      hebrewDate?: string;
+      gregorianDate?: string;
+      date?: string;
+      createdAt?: string;
+    };
+
 export interface Donor {
   id: string;
   donorNumber: string;
@@ -26,4 +39,6 @@ export interface Donor {
   email: string;
   donations: Donation[];
   totalDonations: number;
+  prayerNames?: DonorNameEntry[];
+  yahrzeitNames?: DonorNameEntry[];
 }


### PR DESCRIPTION
## Summary
- add a donor profile card with four tabs for donor details, donations, prayer names, and yahrzeit names, including empty states
- capture optional prayer and yahrzeit name lists when loading donors and surface them through the shared donor type

## Testing
- npm run lint *(fails: missing @eslint/js because npm install is blocked by the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d014e2272083238eb3e28595284672