### PR TITLE
Add home page navigation hub

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import Layout from './components/Layout';
+import HomePage from './components/HomePage';
 import UploadsPage from './components/UploadsPage';
 import DonorsPage from './components/DonorsPage';
 import PdfListPage from './components/PdfListPage';
@@ -11,7 +12,7 @@ function App() {
     <Router>
       <Layout>
         <Routes>
-          <Route path="/" element={<UploadsPage />} />
+          <Route path="/" element={<HomePage />} />
           <Route path="/uploads" element={<UploadsPage />} />
           <Route path="/pdfs" element={<PdfListPage />} />
           <Route path="/donors" element={<DonorsPage />} />

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Upload, FileText, Users, HandCoins } from 'lucide-react';
+
+interface PageLink {
+  title: string;
+  description: string;
+  to: string;
+  icon: React.ReactNode;
+}
+
+const pageLinks: PageLink[] = [
+  {
+    title: 'העלאות קבצים',
+    description: 'נהל והעלה קבצי Excel ו-PDF למערכת',
+    to: '/uploads',
+    icon: <Upload className="h-12 w-12 text-blue-600" />
+  },
+  {
+    title: 'קבצי PDF',
+    description: 'צפה ונהל את כל קבצי ה-PDF במערכת',
+    to: '/pdfs',
+    icon: <FileText className="h-12 w-12 text-blue-600" />
+  },
+  {
+    title: 'תורמים',
+    description: 'נהל את רשימת התורמים ופרטי הקשר שלהם',
+    to: '/donors',
+    icon: <Users className="h-12 w-12 text-blue-600" />
+  },
+  {
+    title: 'תרומות',
+    description: 'עקוב אחר תרומות והיסטוריה פיננסית',
+    to: '/donations',
+    icon: <HandCoins className="h-12 w-12 text-blue-600" />
+  }
+];
+
+export default function HomePage() {
+  return (
+    <div className="space-y-8">
+      <div className="text-center space-y-4">
+        <h1 className="text-4xl font-bold text-gray-900">ברוכים הבאים למערכת הניהול</h1>
+        <p className="text-lg text-gray-600">
+          בחרו באחד מהאזורים הבאים כדי להתחיל לעבוד עם המערכת
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+        {pageLinks.map(page => (
+          <Link
+            key={page.to}
+            to={page.to}
+            className="block bg-white rounded-2xl shadow-lg hover:shadow-xl transition-shadow p-8 border border-transparent hover:border-blue-200"
+          >
+            <div className="flex flex-col items-center space-y-6 text-center">
+              <div className="bg-blue-50 rounded-full p-6 w-28 h-28 flex items-center justify-center">
+                {page.icon}
+              </div>
+              <div className="space-y-3">
+                <h2 className="text-2xl font-semibold text-gray-900">{page.title}</h2>
+                <p className="text-gray-600 text-base">{page.description}</p>
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -45,7 +45,7 @@ export default function Layout({ children }: LayoutProps) {
                 <Link
                   to="/uploads"
                   className={`flex items-center space-x-2 space-x-reverse px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                    isActive('/uploads') || isActive('/')
+                    isActive('/uploads')
                       ? 'bg-blue-100 text-blue-700'
                       : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100'
                   }`}


### PR DESCRIPTION
## Summary
- add a dedicated home page with large navigation cards that link to the uploads, pdfs, donors, and donations areas
- update the app router to render the new home page at the root path
- adjust the layout highlighting so that the uploads tab only activates on its own route

## Testing
- npm run build *(fails: vite: not found, dependencies could not be installed due to registry access restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d53bea7e3083238d7c79d0e83a0264