### PR TITLE
Add double-click access to donor and donation detail views

### DIFF
--- a/src/components/DonationsPage.tsx
+++ b/src/components/DonationsPage.tsx
@@ -863,7 +863,16 @@ export default function DonationsPage() {
                 </tr>
               ) : filteredDonations.length > 0 ? (
                 filteredDonations.map(donation => (
-                  <tr key={donation.id} className="hover:bg-gray-50 transition-colors">
+                  <tr
+                    key={donation.id}
+                    className="hover:bg-gray-50 transition-colors cursor-pointer"
+                    onDoubleClick={event => {
+                      if (event.target instanceof HTMLElement && event.target.closest('button, a, input, label')) {
+                        return;
+                      }
+                      openEditModal(donation);
+                    }}
+                  >
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
                       <div className="flex flex-col">
                         <span>{donation.donorName}</span>

--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -1866,7 +1866,10 @@ export default function DonorsPage() {
             return (
               <div key={donor.id} className="px-6 py-4">
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4 space-x-reverse">
+                  <div
+                    className="flex items-center space-x-4 space-x-reverse"
+                    onDoubleClick={() => setSelectedDonor(donor)}
+                  >
                     <div className="bg-blue-100 rounded-full p-3">
                       <Users className="h-6 w-6 text-blue-600" />
                     </div>


### PR DESCRIPTION
## Summary
- allow double-clicking donor rows to immediately open the donor card view
- enable double-click on donation table rows to open the existing details modal while ignoring interactive controls

## Testing
- npm run lint *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68d8fe5a3a7c8323a0fb039ad092afb9