### PR TITLE
Improve keyboard focus for donor and donation rows

### DIFF
--- a/src/components/DonationsPage.tsx
+++ b/src/components/DonationsPage.tsx
@@ -399,7 +399,7 @@ export default function DonationsPage() {
 
     setFocusedDonationIndex(prev => {
       if (prev == null) {
-        return prev;
+        return 0;
       }
 
       if (prev >= filteredDonations.length) {

--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -902,7 +902,7 @@ export default function DonorsPage() {
 
     setFocusedDonorIndex(prev => {
       if (prev == null) {
-        return prev;
+        return 0;
       }
 
       if (prev >= filteredDonors.length) {


### PR DESCRIPTION
## Summary
- automatically focus the first donation row once results are available so arrow navigation can start immediately
- apply the same default focus behavior to the donor list so Enter opens the donor card without extra clicks

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68d9024e2bf08323a32a9d199c20dfd2