### PR TITLE
Replace IdCard icon with supported alternative

### DIFF
--- a/src/components/DonationsPage.tsx
+++ b/src/components/DonationsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
-  IdCard,
+  UserRound,
   Mail,
   Pencil,
   Search,
@@ -974,7 +974,7 @@ export default function DonationsPage() {
                           className="inline-flex h-9 w-9 items-center justify-center text-purple-600 hover:text-purple-700 bg-purple-50 hover:bg-purple-100 disabled:opacity-60 disabled:cursor-not-allowed rounded-full transition-colors"
                           aria-label="פתח כרטיס תורם"
                         >
-                          <IdCard className="h-4 w-4" />
+                          <UserRound className="h-4 w-4" />
                           <span className="sr-only">פתח כרטיס תורם</span>
                         </button>
                         <button


### PR DESCRIPTION
## Summary
- replace the unavailable IdCard import on the donations page with the existing UserRound icon

## Testing
- npm run build *(fails: vite not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d90392c10c8323a74c928440fd9dc0