### PR TITLE
Enable double-click to open donor and donation details

### DIFF
--- a/src/components/DonationsPage.tsx
+++ b/src/components/DonationsPage.tsx
@@ -937,6 +937,7 @@ export default function DonationsPage() {
                       tabIndex={isTabStop ? 0 : -1}
                       onFocus={() => setFocusedDonationIndex(index)}
                       onKeyDown={event => handleDonationRowKeyDown(event, index, donation)}
+                      onDoubleClick={() => openEditModal(donation)}
                     >
 
                     <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">

--- a/src/components/DonorsPage.tsx
+++ b/src/components/DonorsPage.tsx
@@ -1931,13 +1931,11 @@ export default function DonorsPage() {
                 tabIndex={isTabStop ? 0 : -1}
                 onFocus={() => setFocusedDonorIndex(index)}
                 onKeyDown={event => handleDonorRowKeyDown(event, index, donor)}
+                onDoubleClick={() => setSelectedDonor(donor)}
                 aria-expanded={selectedDonor?.id === donor.id}
               >
                 <div className="flex items-center justify-between">
-                  <div
-                    className="flex items-center space-x-4 space-x-reverse"
-                    onDoubleClick={() => setSelectedDonor(donor)}
-                  >
+                  <div className="flex items-center space-x-4 space-x-reverse">
                     <div className="bg-blue-100 rounded-full p-3">
                       <Users className="h-6 w-6 text-blue-600" />
                     </div>


### PR DESCRIPTION
## Summary
- allow double-clicking a donor row to immediately open the donor card
- trigger the donation details modal when double-clicking a donation row

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d90351c2588323a65810e7a214f2a7