### PR TITLE
Configure server dotenv path

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,12 @@
-import 'dotenv/config';
+import dotenv from 'dotenv';
 import { createServer } from 'http';
 import { appendFile, existsSync, mkdirSync, writeFile, createReadStream, readdir, readFileSync, writeFileSync } from 'fs';
 import { resolve, basename, extname } from 'path';
 import { Pool } from 'pg';
 import { PDFDocument, StandardFonts, rgb } from 'pdf-lib';
 import XLSX from 'xlsx';
+
+dotenv.config({ path: resolve('/root/crm/.env') });
 
 console.log('CWD:', process.cwd());
 console.log('ENV sample:', {


### PR DESCRIPTION
### Motivation
- Ensure the server loads environment variables from a predictable location instead of relying on an automatic side-effect import.
- Make configuration explicit for deployments where the `.env` file is located at `/root/crm/.env`.
- Avoid potential issues with differing module import semantics by using the `dotenv` API directly.

### Description
- Replaced the side-effect import `import 'dotenv/config'` with `import dotenv from 'dotenv'`.
- Added an explicit call to `dotenv.config({ path: resolve('/root/crm/.env') })` at the top of `server/index.js`.
- Used the existing `resolve` import from `path` to build the absolute path to the `.env` file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695d6eb581cc8323aab32bcba942cc96)